### PR TITLE
Comparing for guests was broken

### DIFF
--- a/Plugin/Customer/ResourceModel/Visitor.php
+++ b/Plugin/Customer/ResourceModel/Visitor.php
@@ -17,9 +17,12 @@ class Visitor
 {
     public function aroundSave(
         \Magento\Customer\Model\ResourceModel\Visitor $subject,
-        callable $proceed
-    )
-    {
-        return $this;
+        callable $proceed,
+        \Magento\Framework\Model\AbstractModel $object
+    ) {
+        if ($object->getSessionId()) {
+            $object->setId(substr(base_convert($object->getSessionId(), 36, 10), 0, 10));
+        }
+        return $subject;
     }
 }


### PR DESCRIPTION
Hi Jisse,

The compare function is broken for guest visitors if this plugin is installed (See #4).
By converting the session ID to a decimal string and using the first 10 digits, the simulated visitor ID is compatible with the `catalog_compare_item.visitor_id` column. I am aware that there is a slight collision risk, however with an `int(10)` this is very unlikely. The performance gain is worth more in this case. If you have a better solution for this, please let me know.

Fixes #4