### PR TITLE
Convert the session ID to an integer between 0 and 4294967295

### DIFF
--- a/Plugin/Customer/ResourceModel/Visitor.php
+++ b/Plugin/Customer/ResourceModel/Visitor.php
@@ -21,14 +21,25 @@ use Magento\Framework\Model\AbstractModel;
  */
 class Visitor
 {
+    /**
+     * Convert the session ID to an integer between 0 and 4294967295 (#FFFFFFFF)
+     *
+     * @param VisitorResourceModel $subject
+     * @param callable $proceed
+     * @param AbstractModel $object
+     *
+     * @return VisitorResourceModel
+     */
     public function aroundSave(
         VisitorResourceModel $subject,
         callable $proceed,
         AbstractModel $object
     ) {
         if ($object->getSessionId()) {
-            $converted = base_convert($object->getSessionId(), 36, 10);
-            $object->setId($converted);
+            $hexConverted = base_convert($object->getSessionId(), 36, 16);
+            $truncatedHex = substr($hexConverted, 0, 8);
+            $decConverted = base_convert($truncatedHex, 16, 10);
+            $object->setId($decConverted);
         }
 
         return $subject;


### PR DESCRIPTION
@jissereitsma this is likely to be related to the one issue that is open now. If the converted session ID is too high it is saved as the max value: 4294967295 and the session is lost. This will only be the case if the session ID converts to a hex number that is higher than 4294967295. In that case this fixes #8.
This addition ensures that the converted ID is between 0 and 4294967295.